### PR TITLE
Refactor auth logic into service layer

### DIFF
--- a/lib/auth/LoginPage.dart
+++ b/lib/auth/LoginPage.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart'; 
-import 'package:bada_app/frontPage/SignupPage.dart';
+import 'package:bada_app/auth/SignupPage.dart';
+import 'package:bada_app/services/auth_service.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -11,7 +12,32 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final AuthService _authService = AuthService();
   bool _isPasswordVisible = false;
+
+  Future<void> _login() async {
+    if (_emailController.text.trim().isEmpty || _passwordController.text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이메일과 비밀번호를 입력해주세요.'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    try {
+      await _authService.signIn(
+        email: _emailController.text.trim(),
+        password: _passwordController.text.trim(),
+      );
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('로그인 성공!'), backgroundColor: Color(0xFF10B981)),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('로그인 실패: ${e.toString()}'), backgroundColor: Colors.red),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -161,9 +187,7 @@ class _LoginPageState extends State<LoginPage> {
                       
                       // Login Button
                       ElevatedButton(
-                        onPressed: () {
-                          // 로그인 기능 구현
-                        },
+                        onPressed: _login,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: const Color(0xFF1E3A8A),
                           foregroundColor: Colors.white,

--- a/lib/auth/SignupPage.dart
+++ b/lib/auth/SignupPage.dart
@@ -1,5 +1,5 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:bada_app/services/auth_service.dart';
 
 class SignupPage extends StatefulWidget {
   const SignupPage({super.key});
@@ -12,6 +12,7 @@ class _SignupPageState extends State<SignupPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
+  final AuthService _authService = AuthService();
   String errorMessage = '';
   bool _isPasswordVisible = false;
   bool _isConfirmPasswordVisible = false;
@@ -48,7 +49,7 @@ class _SignupPageState extends State<SignupPage> {
     });
 
     try {
-      await FirebaseAuth.instance.createUserWithEmailAndPassword(
+      await _authService.signUp(
         email: _emailController.text.trim(),
         password: _passwordController.text.trim(),
       );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import "package:firebase_core/firebase_core.dart";
-import "frontPage/LoginPage.dart";
+import 'auth/LoginPage.dart';
 
 void main() async {
     WidgetsFlutterBinding.ensureInitialized();

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,17 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+class AuthService {
+  final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+
+  Future<UserCredential> signUp({required String email, required String password}) async {
+    return _firebaseAuth.createUserWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<UserCredential> signIn({required String email, required String password}) async {
+    return _firebaseAuth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<void> signOut() async {
+    await _firebaseAuth.signOut();
+  }
+}


### PR DESCRIPTION
## Summary
- create `AuthService` to handle Firebase authentication
- connect `SignupPage` and `LoginPage` to the service
- fix import paths in `main.dart`
- clean up unused old service file

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686954b104fc832db24d65de7aacb85e